### PR TITLE
Changes to form field options to allow multiple select toggle for radio fields. fixed non working multi select toggle for selector box

### DIFF
--- a/src/components/form-builder/InputSettingsList.tsx
+++ b/src/components/form-builder/InputSettingsList.tsx
@@ -242,7 +242,7 @@ export function InputSettingsList({
                     )}
 
                     {item.fieldType === "options" &&
-                      item.inputType === "select" && (
+                      (item.inputType === "select" || item.inputType === "radio") && (
                         <Checkbox
                           className="py-2"
                           onChange={(e) =>

--- a/src/components/form-builder/InputsConfiguration.tsx
+++ b/src/components/form-builder/InputsConfiguration.tsx
@@ -319,7 +319,7 @@ export function InputsConfiguration({
                       />
                     )}
 
-                    {field.inputType === "select" && (
+                    {(field.inputType === "select" || field.inputType === "radio") && (
                       <Checkbox
                         onClick={(e) =>
                           onFieldChange(

--- a/src/components/forms/components/input.tsx
+++ b/src/components/forms/components/input.tsx
@@ -1,6 +1,7 @@
 import EventForm from "@/models/event-form";
 import { MultiSelect } from "@/components/multi-select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Checkbox } from "@/components/ui/checkbox";
 import eq from "lodash/eq";
 import React from "react";
 import { Label } from "@/components/ui/label";
@@ -8,24 +9,43 @@ import { Select } from "@/components/ui/select";
 
 export const OptionsInput = React.memo(
   ({ field }: { field: EventForm.HHFieldWithPosition | EventForm.HHField }) => {
-    const inputProps = {
-      // @ts-expect-error
-      placeholder: field.placeholder,
-      label: field.name,
-      description: field.description,
-      required: field.required,
-      // @ts-expect-error
-      multi: field.multi,
-      // value: field.value,
-    };
+    // @ts-expect-error - multi exists on OptionsField but not on all HHField variants
+    const isMulti = Boolean(field.multi);
+    const options: EventForm.FieldOption[] = field.options || [];
 
     switch (field.inputType) {
       case "radio":
+        if (isMulti) {
+          return (
+            <div>
+              <Label>{field.name}</Label>
+              {field.description && (
+                <p className="text-sm text-muted-foreground">
+                  {field.description}
+                </p>
+              )}
+              <div className="mt-2 space-y-2">
+                {options.map((option) => (
+                  <Checkbox
+                    key={option.value}
+                    id={`${field.name}-${option.value}`}
+                    label={option.label}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        }
         return (
-          // @ts-expect-erro
-          <RadioGroup name={field.name} {...inputProps}>
+          <RadioGroup name={field.name}>
+            <Label>{field.name}</Label>
+            {field.description && (
+              <p className="text-sm text-muted-foreground">
+                {field.description}
+              </p>
+            )}
             <div className="mt-2">
-              {field.options.map((option) => (
+              {options.map((option) => (
                 <div className="flex items-center space-x-2" key={option.value}>
                   <RadioGroupItem value={option.value} id={option.value} />
                   <Label htmlFor={option.value}>{option.label}</Label>
@@ -36,30 +56,26 @@ export const OptionsInput = React.memo(
         );
       case "select":
       default:
-        // @ts-expect-error
-        if (field.multi) {
+        if (isMulti) {
           return (
             <MultiSelect
-              // @ts-expect-error
-              data={field.options}
-              // @ts-expect-error
-              multiple={field.multi}
-              {...inputProps}
-              // @ts-expect-error
-              // field={field}
-            />
-          );
-        } else {
-          return (
-            // @ts-expect-erro
-            <Select
-              options={field.options || []}
-              {...inputProps}
-              // field={field}
+              options={options}
+              onValueChange={() => {}}
+              placeholder={field.name}
+              defaultValue={[]}
             />
           );
         }
+        return (
+          <Select name={field.name}>
+            {options.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        );
     }
   },
-  (pres, next) => eq(pres.field, next.field)
+  (pres, next) => eq(pres.field, next.field),
 );

--- a/src/components/forms/fields.ts
+++ b/src/components/forms/fields.ts
@@ -244,7 +244,7 @@ export const createOptionsField = <TOptions extends string | FieldOption>(
     fieldType: "options" as const,
 
     // @ts-expect-error
-    multi: _type == "radio" ? false : Boolean(opts?.multi),
+    multi: Boolean(opts?.multi),
     options: opts?.options ?? [],
   };
 };

--- a/src/models/event-form.ts
+++ b/src/models/event-form.ts
@@ -338,21 +338,12 @@ namespace EventForm {
     options: FieldOption[];
   };
 
-  export type OptionsField = HHFieldBase &
-    (
-      | {
-          fieldType: "options";
-          inputType: "radio";
-          multi: false;
-          options: FieldOption[];
-        }
-      | {
-          fieldType: "options";
-          inputType: "checkbox" | "select";
-          multi: boolean;
-          options: FieldOption[];
-        }
-    );
+  export type OptionsField = HHFieldBase & {
+    fieldType: "options";
+    inputType: "radio" | "checkbox" | "select";
+    multi: boolean;
+    options: FieldOption[];
+  };
 
   export type DiagnosisField = HHFieldBase & {
     fieldType: "diagnosis";

--- a/src/routes/app/data.events.tsx
+++ b/src/routes/app/data.events.tsx
@@ -238,7 +238,11 @@ function RouteComponent() {
                       );
                     }
                     return (
-                      <TableCell key={column.id}>{field?.value}</TableCell>
+                      <TableCell key={column.id}>
+                        {Array.isArray(field?.value)
+                          ? field.value.join(", ")
+                          : field?.value}
+                      </TableCell>
                     );
                   })}
                 </TableRow>

--- a/src/routes/app/event-forms.edit.$.tsx
+++ b/src/routes/app/event-forms.edit.$.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/utils";
 import { Result } from "@/lib/result";
 import { DatePickerInput } from "@/components/date-picker-input";
+import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { InputsConfiguration } from "@/components/form-builder/InputsConfiguration";
 import { TranslationBadges } from "@/components/form-builder/TranslationBadges";
@@ -494,6 +495,32 @@ function RouteComponent() {
                   </div>
                 );
               case "options":
+                if (field.inputType === "radio" && field.multi) {
+                  return (
+                    <div key={field.id}>
+                      <Label>
+                        {field.name}
+                        {field.required && (
+                          <span className="text-destructive"> *</span>
+                        )}
+                      </Label>
+                      {field.description && (
+                        <p className="text-sm text-muted-foreground">
+                          {field.description}
+                        </p>
+                      )}
+                      <div className="mt-2 space-y-2">
+                        {field.options.map((option) => (
+                          <Checkbox
+                            key={option.value}
+                            id={`${field.id}-${option.value}`}
+                            label={option.label}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                }
                 if (field.inputType === "radio") {
                   return (
                     <div key={field.id}>
@@ -502,6 +529,18 @@ function RouteComponent() {
                         description={field.description}
                         withAsterisk={field.required}
                         data={field.options as (string | RadioOption)[]}
+                      />
+                    </div>
+                  );
+                }
+                if (field.multi) {
+                  return (
+                    <div key={field.id}>
+                      <MultiSelect
+                        options={field.options}
+                        onValueChange={() => {}}
+                        placeholder={field.name}
+                        defaultValue={[]}
                       />
                     </div>
                   );


### PR DESCRIPTION
 Summary
  - Adds a "multi" toggle to radio and select inputs in the form builder (previously only checkbox fields could be multi-select, and the select toggle wasn't wired correctly).
  - When multi is enabled on a radio field, the form renders as a checkbox group; select fields render as a MultiSelect dropdown.
  - Fixes the events data table so multi-value field values render as a comma-separated string instead of [object Object]/blank.

  Changes
  - models/event-form.ts: collapse the discriminated OptionsField union so multi: boolean is valid for radio/checkbox/select, not just checkbox/select.
  - form-builder/InputSettingsList.tsx, InputsConfiguration.tsx: show the multi-select checkbox toggle for both select and radio input types.
  - forms/fields.ts: drop the hard-coded multi: false override for radios; honor opts.multi.
  - forms/components/input.tsx: render radio-multi as a checkbox list and select-multi via MultiSelect; clean up the stale @ts-expect-error props passthrough.
  - routes/app/event-forms.edit.$.tsx: mirror the multi-radio / multi-select rendering in the form edit preview.
  - routes/app/data.events.tsx: join array values with ", " when rendering event rows.

  Test plan
  - Create a form with a radio field, toggle multi on, submit — values save as an array and render correctly in the events table.
  - Create a form with a select field, toggle multi on, confirm MultiSelect UI appears and saves multiple values.
  - Existing single-select radio/select fields still render and save as before.
  - Event list view shows comma-separated values for multi fields, single values unchanged.
