### PR TITLE
docs: fix mobile contributing link

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -351,7 +351,7 @@ Features on the roadmap represent the vision for the mobile app over the coming 
 
 ## Contributing
 
-Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.
+Please see the root README's [Contributing](../../README.md#contributing) section for more information.
 
 ## Credits
 


### PR DESCRIPTION
﻿## Summary
- replace the mobile README's missing local `CONTRIBUTING.md` link
- point contributors to the root README contributing section instead

## Changes
- `apps/mobile/README.md`: updates the Contributing link target.

## Validation
- git diff --check
- rg confirmed the root README has a `## Contributing` section and the mobile README points to it

## Notes
Documentation-only change. No runtime behavior changes.
