### PR TITLE
docs: fix root contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ This codebase handles protected health information. Treat it accordingly:
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) where present, plus the per-app
-guidelines. In short:
+See the server [`CONTRIBUTING.md`](apps/server/CONTRIBUTING.md), plus any
+per-app guidelines. In short:
 
 - Code must pass `pnpm run lint`
 - App-specific tests and type checks must pass before opening a PR


### PR DESCRIPTION
﻿## Summary
- replace the missing root `CONTRIBUTING.md` link in the root README
- point contributors to the existing server contribution guide

## Changes
- `README.md`: updates the Contributing section link target.

## Validation
- git diff --check
- confirmed `apps/server/CONTRIBUTING.md` exists
- rg confirmed the root README now links to `apps/server/CONTRIBUTING.md`

## Notes
Documentation-only change. No runtime behavior changes.
